### PR TITLE
Add support for easy flashes handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ This command requires you to have Composer installed globally, as explained
 in the [installation chapter](https://getcomposer.org/doc/00-intro.md)
 of the Composer documentation.
 
-
 Basic usage
 -----------
 
@@ -59,7 +58,7 @@ Secondly, you need to set the `autofill_variables` option for your routes
 to enable the auto-filling of specific parameters.
 
 **Caution:** This option must be set per route, provide either an array or
-string with named separated by a `,` (`account,id`).
+a string with named separated by a `,` (`account,id`).
 
 ### RouteRedirectResponse
 
@@ -73,9 +72,26 @@ use Rollerworks\Bundle\RouteAutofillBundle\Response\RouteRedirectResponse;
 return new RouteRedirectResponse('route-name');
 ```
 
-That's it. 
+That's it.
+
+#### Flash messages
+
+Additionally you can add [flash messages][0] directly at the response.
+
+```php
+return RouteRedirectResponse::toRoute('route-name')
+    ->withFlash('success', 'translation.id', 'arguments');
+```
+
+When the arguments are empty (null) the message is past added to FlashBag as a string, 
+otherwise it's an array like `['message' => 'message.id' => ['id' => 200]]`.
+
+Translations and special formatting must still be done in the template.
+The `withFlash()` method can be called multiple times if needed.
 
 License
 -------
 
 All contents of this package are released under the [MIT license](LICENSE).
+
+[0]: https://symfony.com/doc/current/controller.html#flash-messages

--- a/src/DependencyInjection/DependencyExtension.php
+++ b/src/DependencyInjection/DependencyExtension.php
@@ -41,7 +41,8 @@ final class DependencyExtension extends Extension
 
         $container->register(RouteRedirectResponseListener::class)
             ->addTag('kernel.event_subscriber')
-            ->addArgument(new Reference(AutoFilledUrlGenerator::class));
+            ->addArgument(new Reference(AutoFilledUrlGenerator::class))
+            ->addArgument(new Reference('session'));
     }
 
     public function getAlias(): string

--- a/src/Response/RouteRedirectResponse.php
+++ b/src/Response/RouteRedirectResponse.php
@@ -20,12 +20,18 @@ class RouteRedirectResponse
     protected $route;
     protected $parameters = [];
     protected $status = 302;
+    protected $flashes = [];
 
     public function __construct(string $route, array $parameters = [], int $status = 302)
     {
         $this->route = $route;
         $this->parameters = $parameters;
         $this->status = $status;
+    }
+
+    public static function toRoute(string $route, array $parameters = [])
+    {
+        return new static($route, $parameters);
     }
 
     public static function permanent(string $route, array $parameters = [])
@@ -46,5 +52,17 @@ class RouteRedirectResponse
     public function getStatus(): int
     {
         return $this->status;
+    }
+
+    public function withFlash(string $type, string $message, ?array $arguments = null)
+    {
+        $this->flashes[] = [$type, $message, $arguments];
+
+        return $this;
+    }
+
+    public function getFlashes(): array
+    {
+        return $this->flashes;
     }
 }


### PR DESCRIPTION
It's a common practice to show a flash message after a redirect, rather than having to get a session manually (ensuring its started) you can use now use the `withFlash()` method.

Example:

```php
return RouteRedirectResponse::toRoute('park_manager.client_section.webhosting.account.ftp.user_list')
                ->withFlash('success', 'translation.id', 'arguments');
```

When the arguments are empty (`null`) the message is past added to FlashBag as a string, otherwise it's an array like `['message' => 'message.id' => ['id' => 200]]`.

Translations and special formatting must still be done in the template.